### PR TITLE
Improve dark mode support for storage visualizations

### DIFF
--- a/Sources/Views/Visualization/CapacityBreakdownView.swift
+++ b/Sources/Views/Visualization/CapacityBreakdownView.swift
@@ -49,7 +49,8 @@ struct CapacityBreakdownView: View {
     private func segmentColor(for index: Int, isUsed: Bool) -> Color {
         let baseColors: [Color] = [.blue, .green, .orange, .purple, .pink, .cyan]
         let baseColor = baseColors[index % baseColors.count]
-        return isUsed ? baseColor : baseColor.opacity(0.3)
+        // Use higher opacity for free space to ensure visibility in dark mode
+        return isUsed ? baseColor : baseColor.opacity(0.4)
     }
 
     var body: some View {

--- a/Sources/Views/Visualization/DriveBayView.swift
+++ b/Sources/Views/Visualization/DriveBayView.swift
@@ -18,7 +18,7 @@ enum DriveBayStatus {
 
     var color: Color {
         switch self {
-        case .empty: return .gray.opacity(0.3)
+        case .empty: return Color(nsColor: .separatorColor)
         case .present: return .green
         case .warning: return .yellow
         case .failed: return .red
@@ -147,11 +147,11 @@ struct DriveBaySlot: View {
             // Bay visual
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(bay.status.color.opacity(0.2))
+                    .fill(bay.status.color.opacity(bay.status == .empty ? 0.1 : 0.2))
                     .frame(width: 60, height: 100)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .stroke(bay.status.color, lineWidth: 2)
+                            .stroke(bay.status.color.opacity(bay.status == .empty ? 0.5 : 1.0), lineWidth: 2)
                     )
 
                 VStack(spacing: 8) {

--- a/Sources/Views/Visualization/StorageVisualizationView.swift
+++ b/Sources/Views/Visualization/StorageVisualizationView.swift
@@ -88,7 +88,7 @@ struct CapacityOverview: View {
             // Legend
             HStack(spacing: 24) {
                 LegendItem(color: usedPercentageColor, label: "Used", value: formatBytes(usedSpace))
-                LegendItem(color: Color.secondary.opacity(0.3), label: "Free", value: formatBytes(freeSpace))
+                LegendItem(color: Color(nsColor: .tertiaryLabelColor), label: "Free", value: formatBytes(freeSpace))
                 Spacer()
                 Text("\(Int(usedPercentage))% used")
                     .font(.caption)
@@ -239,7 +239,7 @@ struct VolumeBarView: View {
             }
         }
         .padding(8)
-        .background(Color.secondary.opacity(0.05))
+        .background(Color(nsColor: .quaternarySystemFill))
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }


### PR DESCRIPTION
## Summary
Fixes #4

This PR improves dark mode support across storage visualization components.

## Changes

### DriveBayView.swift
- Changed empty drive bay color from `.gray.opacity(0.3)` to `Color(nsColor: .separatorColor)` for proper system appearance adaptation
- Adjusted empty bay fill and stroke opacity for better visibility in dark mode

### CapacityBreakdownView.swift  
- Increased free space segment opacity from 0.3 to 0.4 for better visibility in dark mode

### StorageVisualizationView.swift
- Changed free space legend color to use `NSColor.tertiaryLabelColor` (semantic color)
- Changed volume card background to use `NSColor.quaternarySystemFill` for proper dark mode adaptation

## Testing
Tested visually in both Light and Dark mode:
- Drive bay empty slots now have consistent appearance
- Donut chart segments are visible in both modes
- Progress bars maintain good contrast
- Text on colored backgrounds remains readable

## Screenshots
_Visual changes are subtle but ensure proper adaptation between modes_